### PR TITLE
fix: resolve sudo not being installed

### DIFF
--- a/elixir/Dockerfile.ci
+++ b/elixir/Dockerfile.ci
@@ -6,7 +6,7 @@ LABEL maintainer="bonjour@civilcode.io"
 
 RUN apk update \
     apk upgrade --no-cache \
-    apk add git xvfb sudo openssh-client ca-certificates tar gzip parallel net-tools \
+    apk add git xvfb openssh-client ca-certificates tar gzip parallel net-tools \
             unzip bzip2 gnupg curl wget
 
 # install jq
@@ -33,7 +33,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
   && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && dockerize --version
 
-RUN apk add shadow \
+RUN apk add sudo shadow \
   && groupadd --gid 3434 circleci \
   && useradd --uid 3434 --gid circleci --shell /bin/bash --create-home circleci \
   && echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci \


### PR DESCRIPTION
Admittedly, I'm not 100% sure why sudo was not being installed in apk
add. Moving it resolved this problem. The upside of this, the location
of the package is where it is needed.