### PR TITLE
Upgrade to elixir-1.8.1

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,6 +1,6 @@
 # As our primary development platform is Elixir, let's use that as our base image. This also
 # includes a lot of the base dependencies required.
-FROM bitwalker/alpine-elixir-phoenix:1.8.0
+FROM bitwalker/alpine-elixir-phoenix:1.8.1
 
 LABEL maintainer="bonjour@civilcode.io"
 

--- a/elixir/Dockerfile.ci
+++ b/elixir/Dockerfile.ci
@@ -1,6 +1,6 @@
 # Based on https://hub.docker.com/r/circleci/elixir/~/dockerfile/
 
-FROM bitwalker/alpine-elixir-phoenix:1.8.0
+FROM bitwalker/alpine-elixir-phoenix:1.8.1
 
 LABEL maintainer="bonjour@civilcode.io"
 
@@ -23,7 +23,7 @@ RUN apk add docker \
 # docker compose
 # https://wiki.alpinelinux.org/wiki/Docker#Docker_Compose
 RUN apk add py-pip \
-  && pip install docker-compose \
+  && pip install docker-compose==1.23.2 \
   && docker-compose version
 
 # install dockerize

--- a/elixir/Dockerfile.dev
+++ b/elixir/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix:1.8.0
+FROM bitwalker/alpine-elixir-phoenix:1.8.1
 
 LABEL maintainer="bonjour@civilcode.io"
 
@@ -11,7 +11,7 @@ RUN git clone https://github.com/facebook/watchman.git && \
    cd watchman && \
    git checkout v4.9.0 && \
   ./autogen.sh && \
-  ./configure && \
+  ./configure --enable-lenient && \
   make && \
   make install
 

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -5,7 +5,7 @@ These Dockerfiles are used as base images for local development and CI.
 ## Development
 
     docker build --no-cache -t civilcode/elixir-dev:1.6.5a -f elixir/Dockerfile.dev .
-    docker run -i --name elixir-dev-runtime -t --rm civilcode/elixir-dev:1.6.5a zsh
+    docker run -i --name elixir-dev-runtime -t --rm civilcode/elixir-dev:1.6.5a
     docker push civilcode/elixir-dev:1.6.5a
 
 ## Versioning


### PR DESCRIPTION
now passing  `--enable-lenient` to watchman ./configure as per
https://github.com/facebook/watchman/issues/638 in order to solve (when building `elixir-dev`):

```
scm/Mercurial.cpp: In constructor 'watchman::Mercurial::infoCache::infoCache(std::__cxx11::string)':
scm/Mercurial.cpp:16:40: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct watchman::FileInformation'; use assignment or value-initialization instead [-Werror=class-memaccess]
   memset(&dirstate, 0, sizeof(dirstate));
                                        ^
In file included from scm/Mercurial.h:10,
                 from scm/Mercurial.cpp:3:
./FileInformation.h:18:8: note: 'struct watchman::FileInformation' declared here
 struct FileInformation {
        ^~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[1]: *** [Makefile:4446: scm/watchman-Mercurial.o] Error 1
make: *** [Makefile:1264: all] Error 2
```

error when building `elixir-ci`

```
      gcc -fno-strict-aliasing -Os -fomit-frame-pointer -g -DNDEBUG -Os -fomit-frame-pointer -g -DTHREAD_STACK_SIZE=0x100000 -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python2.7 -c c/_cffi_backend.c -o build/temp.linux-x86_64-2.7/c/_cffi_backend.o
      c/_cffi_backend.c:2:10: fatal error: Python.h: No such file or directory
       #include <Python.h>
                ^~~~~~~~~~
      compilation terminated.
      error: command 'gcc' failed with exit status 1
  
      ----------------------------------------
  Command "/usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-VmhNAV/cffi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-2MECNl/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-YiWoxP --compile" failed with error code 1 in /tmp/pip-install-VmhNAV/cffi/
  
  ----------------------------------------
Command "/usr/bin/python2 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-YiWoxP --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel "cffi>=1.1; python_implementation != 'PyPy'"" failed with error code 1 in None
The command '/bin/sh -c apk add py-pip   && pip install docker-compose   && docker-compose version' returned a non-zero code: 1
```

also unable to build it on master:
```
  Could not find a version that satisfies the requirement cffi>=1.1 (from versions: )
No matching distribution found for cffi>=1.1
You are using pip version 10.0.1, however version 19.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c apk add py-pip   && pip install docker-compose   && docker-compose version' returned a non-zero code: 1
```

fixed with pinning version @ `1.23.2` as per
https://github.com/docker/compose/issues/6617
