### PR TITLE
Update postgres client

### DIFF
--- a/elixir/Dockerfile.dev
+++ b/elixir/Dockerfile.dev
@@ -1,14 +1,11 @@
-# VERSION: 1.8.1b
+# VERSION: 1.8.1c
 
 FROM bitwalker/alpine-elixir-phoenix:1.8.1
 
 LABEL maintainer="bonjour@civilcode.io"
 
 # install Postgresql (for demo data seeding)
-# Use 3.7 repo in order to get a version of Postgresql as close as possible as the
-# one on Heroku. Note that the version of postgresql-client in 3.7 repo may change in time.
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.7/main' >> /etc/apk/repositories
-RUN apk add --no-cache --virtual .build-deps postgresql-client=10.8-r0
+RUN apk add --no-cache --virtual .build-deps postgresql-client
 
 # install watchman
 RUN apk update && \

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -4,6 +4,8 @@ These Dockerfiles are used as base images for local development and CI.
 
 ## Development
 
+Replace `1.6.5a` with the Elixir version and increment the suffix if required.
+
     docker build --no-cache -t civilcode/elixir-dev:1.6.5a -f elixir/Dockerfile.dev .
     docker run -i --name elixir-dev-runtime -t --rm civilcode/elixir-dev:1.6.5a
     docker push civilcode/elixir-dev:1.6.5a
@@ -12,4 +14,7 @@ These Dockerfiles are used as base images for local development and CI.
 
 *  branch is created for each new version, i.e. `elixir-1.6.5_stable` -> `elixir-1.6.6_stable`
 *  updates to a version
-```
+
+## Links
+
+* [CivilCode Registry](https://cloud.docker.com/u/civilcode/repository/list)


### PR DESCRIPTION
There doesn't seem to be the need to use the 3.7 repo as the client keeps
changing anyway. We've been ok using the client from the edge repo with
Heroku over the last few months. By using the default postgres client we
do not have to worry about updating the postgres client version when it
has been updated/no longer available.