### PR TITLE
Upgrade to elixir 1.9.1

### DIFF
--- a/elixir/Dockerfile.ci
+++ b/elixir/Dockerfile.ci
@@ -1,6 +1,6 @@
 # Based on https://hub.docker.com/r/circleci/elixir/~/dockerfile/
 
-FROM bitwalker/alpine-elixir-phoenix:1.9.0
+FROM bitwalker/alpine-elixir-phoenix:1.9.1
 
 LABEL maintainer="bonjour@civilcode.io"
 

--- a/elixir/Dockerfile.dev
+++ b/elixir/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix:1.9.0
+FROM bitwalker/alpine-elixir-phoenix:1.9.1
 
 LABEL maintainer="bonjour@civilcode.io"
 
@@ -6,12 +6,12 @@ LABEL maintainer="bonjour@civilcode.io"
 # Use 3.7 repo in order to get a version of Postgresql as close as possible as the
 # one on Heroku. Note that the version of postgresql-client in 3.7 repo may change in time.
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.7/main' >> /etc/apk/repositories
-RUN apk add --no-cache --virtual .build-deps postgresql-client=11.5-r0
+RUN apk add --no-cache --virtual .build-deps postgresql-client=11.5-r1
 
 # install watchman
 RUN apk update && \
     apk upgrade --no-cache && \
-    apk add autoconf automake libtool python-dev linux-headers
+    apk add autoconf automake libtool python-dev linux-headers libressl-dev
 
 RUN git clone https://github.com/facebook/watchman.git && \
    cd watchman && \


### PR DESCRIPTION
Required a new package to resolve a watch error:

```
ContentHash.cpp:13:10: fatal error: openssl/sha.h: No such file or directory
 #include <openssl/sha.h>
          ^~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:3312: watchman-ContentHash.o] Error 1
```